### PR TITLE
Set version details as part of build

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -8,6 +8,9 @@ echo '# Building binaries #'
 echo '#####################'
 echo
 
-gox -os="${OS_TARGETS:-linux darwin windows}" \
+gox -ldflags="-X main.version=${TRAVIS_TAG:-unknown} \
+              -X main.revision=${TRAVIS_COMMIT:-unknown} \
+              -X main.built=$(date --iso-8601=seconds)" \
+    -os="${OS_TARGETS:-linux darwin windows}" \
     -arch="${ARCH_TARGETS:-amd64}" \
     -output="dist/{{.OS}}/{{.Arch}}/{{.Dir}}"

--- a/main.go
+++ b/main.go
@@ -9,11 +9,23 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+var (
+	version  = "unknown"
+	revision = "unknown"
+	built    = "unknown"
+)
+
 func main() {
 	app := cli.NewApp()
 	app.Usage = "Alternate implementation of ansible-galaxy tool for downloading Ansible roles."
 	app.HideHelp = true
-	app.Version = "0.9"
+
+	app.Version = version
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println("Version:  ", version)
+		fmt.Println("Revision: ", revision)
+		fmt.Println("Built:    ", built)
+	}
 
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
The linker can overwrite strings; this feature is used to set the version, revision and time of build for the version string.
