### PR TITLE
Omit the symbol table and debug information

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -10,7 +10,8 @@ echo
 
 gox -ldflags="-X main.version=${TRAVIS_TAG:-unknown} \
               -X main.revision=${TRAVIS_COMMIT:-unknown} \
-              -X main.built=$(date --iso-8601=seconds)" \
+              -X main.built=$(date --iso-8601=seconds) \
+              -s" \
     -os="${OS_TARGETS:-linux darwin windows}" \
     -arch="${ARCH_TARGETS:-amd64}" \
     -output="dist/{{.OS}}/{{.Arch}}/{{.Dir}}"


### PR DESCRIPTION
Make the binaries smaller by omitting the symbol table and debug information.
