### PR TITLE
Added force flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ ERROR! Unexpected Exception: [Errno 104] Connection reset by peer
 
 ## Usage guide
 
+**WARNING:** this will delete and replace your existing roles under the role
+path directory.
+
 ```bash
-alt-galaxy install --role-file=/vagrant/provisioning/requirements.yml --roles-path=/etc/ansible/roles
+alt-galaxy install \
+    --role-file=/vagrant/provisioning/requirements.yml \
+    --roles-path=/etc/ansible/roles \
+    --force
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -42,6 +42,10 @@ func main() {
 					Name:  "roles-path",
 					Usage: "The path to the directory containing your roles. The default is the roles_path configured in your ansible.cfg file (/etc/ansible/roles if not configured",
 				},
+				cli.BoolFlag{
+					Name:  "force",
+					Usage: "Force overwriting an existing role",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				roleFile := c.String("role-file")
@@ -52,6 +56,10 @@ func main() {
 				rolesPath := c.String("roles-path")
 				if rolesPath == "" {
 					return errors.New("You must specify the roles path.")
+				}
+				force := c.Bool("force")
+				if !force {
+					return errors.New("This application requires --force to be set.\nWARNING: this will delete and replace your existing roles under the role path directory.")
 				}
 
 				cmd := roleinstaller.RoleInstallerCmd{


### PR DESCRIPTION
Since this applications behaves the same as `ansible-galaxy` with the force flag set, this application should require the force flag to be set as well. This will avoid users accidently deleting their roles using this application.
