### PR TITLE
Added application binaries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,9 @@ _testmain.go
 
 # external packages folder
 vendor/
+
+
+### Application specific ###
+
+/alt-galaxy
+/debug


### PR DESCRIPTION
If you perform a manual build the application binaries end up in the project root by default.
