### PR TITLE
Fixed completion latch failure path

### DIFF
--- a/internal/util/completionlatch.go
+++ b/internal/util/completionlatch.go
@@ -24,9 +24,10 @@ func (latch completionLatchImpl) Failure() {
 }
 
 func (latch completionLatchImpl) Await() bool {
-	result := true
+	finalResult := true
 	for i := 0; i < latch.count; i++ {
-		result = result && <-latch.channel
+		result := <-latch.channel
+		finalResult = finalResult && result
 	}
-	return result
+	return finalResult
 }


### PR DESCRIPTION
`CompletionLatch.Await()` was returning early if a failure occurred. The boolean comparison was short-circuting after the first failure so the loop completed without needed any more results on the channel. This resulted in unpredictable behaviour.