### PR TITLE
Fixed sequence of error output

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -1,8 +1,8 @@
 package message
 
 const (
-	OutMsg MessageType = iota
-	ErrorMsg
+	OutMsg   MessageType = iota
+	ErrorMsg MessageType = iota
 )
 
 type MessageType int

--- a/internal/roleinstaller/roleinstaller.go
+++ b/internal/roleinstaller/roleinstaller.go
@@ -1,12 +1,14 @@
 package roleinstaller
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gantsign/alt-galaxy/internal/application"
 	"github.com/gantsign/alt-galaxy/internal/message"
@@ -49,15 +51,32 @@ type roleInstaller struct {
 }
 
 func (installer *roleInstaller) printOutput() {
+	stdOut := bufio.NewWriter(os.Stdout)
+	stdErr := bufio.NewWriter(os.Stderr)
 	for _, output := range installer.roleOutputBuffers {
 		for msg := range output {
 			switch msg.MessageType {
 			case message.OutMsg:
-				fmt.Println("- ", msg.Body)
+				fmt.Fprintln(stdOut, "- ", msg.Body)
+				stdOut.Flush()
 			case message.ErrorMsg:
-				fmt.Fprintln(os.Stderr, "ERROR! ", msg.Body)
+				// A short sleep helps the stdout and stderr render in the correct order
+				time.Sleep(time.Second)
+
+				fmt.Fprintln(stdErr, "ERROR! ", msg.Body)
+				stdErr.Flush()
+
+				// A short sleep helps the stdout and stderr render in the correct order
+				time.Sleep(time.Second)
 			default:
-				fmt.Fprintln(os.Stderr, fmt.Sprintf("ERROR! Unsupported MessageType: %d", msg.MessageType))
+				// A short sleep helps the stdout and stderr render in the correct order
+				time.Sleep(time.Second)
+
+				fmt.Fprintln(stdErr, fmt.Sprintf("ERROR! Unsupported MessageType: %d", msg.MessageType))
+				stdErr.Flush()
+
+				// A short sleep helps the stdout and stderr render in the correct order
+				time.Sleep(time.Second)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/gantsign/alt-galaxy/internal/application"
 	"github.com/gantsign/alt-galaxy/internal/roleinstaller"
@@ -69,6 +70,9 @@ func main() {
 
 	appError := app.Run(os.Args)
 	if appError != nil {
+		// A short sleep helps the stdout and stderr render in the correct order
+		time.Sleep(time.Second)
+
 		fmt.Fprintln(os.Stderr, appError)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixed issue of `stderr` output being rendered in the wrong sequence relative to `stdout`.