### PR TITLE
Added support for role dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ERROR! Unexpected Exception: [Errno 104] Connection reset by peer
 
 * Implements `ansible-galaxy install` command only.
 * Supports looking up the latest role version from Ansible Galaxy.
+* Supports role dependencies (remote dependencies only)
 * Efficient HTTP implementation, reuses HTTP connections.
 * Fast, roles are installed in parallel making this implementation much faster.
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,0 +1,49 @@
+package metadata
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type ComplexRole struct {
+	Name string `yaml:"role,omitempty"`
+}
+
+type Role struct {
+	Name string
+}
+
+func (role *Role) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Maybe a simple string
+	var roleName string
+	err := unmarshal(&roleName)
+	if err == nil {
+		role.Name = roleName
+		return nil
+	}
+
+	// Maybe an object literal
+	var complexRole ComplexRole
+	err = unmarshal(&complexRole)
+	if err != nil {
+		return err
+	}
+	role.Name = complexRole.Name
+	return nil
+}
+
+type Metadata struct {
+	Dependencies []Role `yaml:"dependencies,omitempty"`
+}
+
+func ParseMetadataFile(filename string) (Metadata, error) {
+	yamlBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return Metadata{}, err
+	}
+	var metadata Metadata
+	err = yaml.Unmarshal(yamlBytes, &metadata)
+
+	return metadata, err
+}

--- a/internal/util/completionlatch.go
+++ b/internal/util/completionlatch.go
@@ -6,6 +6,7 @@ import (
 )
 
 type CompletionLatch interface {
+	TaskAdded()
 	Success()
 	Failure()
 	Await() bool
@@ -30,6 +31,14 @@ func NewCompletionLatch(count int) CompletionLatch {
 	}
 	latch.completionLock.Lock()
 	return latch
+}
+
+func (latch completionLatchImpl) TaskAdded() {
+	latch.updateLock.Lock()
+
+	atomic.AddInt32(latch.remaining, 1)
+
+	latch.updateLock.Unlock()
 }
 
 func (latch completionLatchImpl) Success() {


### PR DESCRIPTION
See: http://docs.ansible.com/ansible/playbooks_roles.html#role-dependencies

Note: only remote dependencies are supported (e.g. {role: '/path/to/common/roles/foo'} will fail).

Enhancement: resolves #17