### PR TITLE
Fixed duplicate role name detection

### DIFF
--- a/internal/roleinstaller/roleinstaller.go
+++ b/internal/roleinstaller/roleinstaller.go
@@ -305,8 +305,8 @@ func (cmd RoleInstallerCmd) Execute() error {
 
 	roleNames := make([]string, len(roles))
 	for index := range roles {
-		if !strings.Contains(roles[index].Src, "://") {
-			roles[index].Name = roles[index].Src
+		if roles[index].Name == "" {
+			roles[index].Name = repoUrlToRoleName(roles[index].Src)
 		}
 		roleNames[index] = roles[index].Name
 	}


### PR DESCRIPTION
Was failing for roles with a `src` URL without an explicit name specified.