### PR TITLE
Simplify process role API

### DIFF
--- a/internal/roleinstaller/internal/step/downloadrole.go
+++ b/internal/roleinstaller/internal/step/downloadrole.go
@@ -8,19 +8,17 @@ import (
 	"github.com/gantsign/alt-galaxy/internal/roleinstaller/internal/pipeline"
 )
 
-func downloadRole(ctx model.Context, step pipeline.Step, role model.Role) {
+func downloadRole(ctx model.Context, role model.Role) (model.Role, error) {
 	destFilePath := path.Join(ctx.RolesPath(), ".downloads", fmt.Sprint(role.Name, ".tar.gz"))
 
 	role.Progressf("downloading role from %s", role.Url)
 	destFilePath, err := ctx.RestClient().DownloadUrl(role.Url, destFilePath)
 	if err != nil {
-		role.Errorf("Failed to download URL [%s].\nCaused by: %s", role.Url, err)
-		step.Fail(role)
-		return
+		return role, fmt.Errorf("Failed to download URL [%s].\nCaused by: %s", role.Url, err)
 	}
 	role.ArchivePath = destFilePath
 
-	step.Success(role)
+	return role, nil
 }
 
 func NewDownloadRole(maxConcurrent int) pipeline.Step {

--- a/internal/roleinstaller/internal/step/untarrole.go
+++ b/internal/roleinstaller/internal/step/untarrole.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/gantsign/alt-galaxy/internal/roleinstaller/internal/model"
@@ -8,19 +9,17 @@ import (
 	"github.com/gantsign/alt-galaxy/internal/untar"
 )
 
-func untarRole(ctx model.Context, step pipeline.Step, role model.Role) {
+func untarRole(ctx model.Context, role model.Role) (model.Role, error) {
 	destDirPath := path.Join(ctx.RolesPath(), role.Name)
 
 	role.Progressf("extracting %s to %s", role.Name, destDirPath)
 
 	err := untar.Untar(role, role.ArchivePath, destDirPath)
 	if err != nil {
-		role.Errorf("Failed to untar archive [%s].\nCaused by: %s", role.ArchivePath, err)
-		step.Fail(role)
-		return
+		return role, fmt.Errorf("Failed to untar archive [%s].\nCaused by: %s", role.ArchivePath, err)
 	}
 
-	step.Success(role)
+	return role, nil
 }
 
 func NewUntarRole(maxConcurrent int) pipeline.Step {


### PR DESCRIPTION
Use standard error handling and have the framework record success/failure.