### PR TITLE
Eliminated duplicate Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ install:
 script:
   - .travis/build.sh
 
+branches:
+  only:
+    - master
+    - /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([\.\-].*)?$/
+
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
For each pull request two builds were being generated:

1. One for the push
2. One for the pull request

This was slowing down development because of the limited number of concurrent builds permitted.

This change ensures only the pull request build is created for pull requests; push builds will still run on the master branch and versioned branches/tags.