### PR TITLE
Added error handling for malformed versions

### DIFF
--- a/internal/restapi/rolequery.go
+++ b/internal/restapi/rolequery.go
@@ -35,14 +35,17 @@ func ParseRoleQueryResponse(bytes []byte) (RoleQueryResponse, error) {
 	return response, err
 }
 
-func (result RoleQueryResult) LatestVersion() string {
+func (result RoleQueryResult) LatestVersion() (string, error) {
 	versions := result.SummaryFields.Versions
 	if len(versions) == 0 {
-		return "master"
+		return "master", nil
 	}
 	libVersions := make([]*version.Version, len(versions))
 	for i, rawVersion := range versions {
-		ver, _ := version.NewVersion(rawVersion.Name)
+		ver, err := version.NewVersion(rawVersion.Name)
+		if err != nil {
+			return "", err
+		}
 		libVersions[i] = ver
 	}
 
@@ -52,11 +55,11 @@ func (result RoleQueryResult) LatestVersion() string {
 	// The version library strips the 'v' prefix; return the version with the 'v' prefix if present.
 	for _, rawVersion := range versions {
 		if rawVersion.Name == ("v" + latestVersion) {
-			return rawVersion.Name
+			return rawVersion.Name, nil
 		}
 	}
 
-	return latestVersion
+	return latestVersion, nil
 }
 
 func (restApi restApiImpl) QueryRolesByName(roleName rolesfile.RoleName) (RoleQueryResponse, error) {

--- a/internal/restapi/rolequery_test.go
+++ b/internal/restapi/rolequery_test.go
@@ -206,7 +206,12 @@ func TestLatestVersionWithoutPrefix(t *testing.T) {
 	expectedVersion := "1.1.3"
 
 	roleDetails := roleQueryResponse.Results[0]
-	actualVersion := roleDetails.LatestVersion()
+
+	actualVersion, err := roleDetails.LatestVersion()
+	if err != nil {
+		t.Errorf("Error obtaining latest version: %+v", err)
+		return
+	}
 
 	if expectedVersion != actualVersion {
 		t.Errorf("Expected [%s] != actual [%s]", expectedVersion, actualVersion)
@@ -287,7 +292,12 @@ func TestLatestVersionWithPrefix(t *testing.T) {
 	expectedVersion := "v2.0.1"
 
 	roleDetails := roleQueryResponse.Results[0]
-	actualVersion := roleDetails.LatestVersion()
+
+	actualVersion, err := roleDetails.LatestVersion()
+	if err != nil {
+		t.Errorf("Error obtaining latest version: %+v", err)
+		return
+	}
 
 	if expectedVersion != actualVersion {
 		t.Errorf("Expected [%s] != actual [%s]", expectedVersion, actualVersion)
@@ -313,7 +323,12 @@ func TestLatestVersionEmpty(t *testing.T) {
 	expectedVersion := "master"
 
 	roleDetails := roleQueryResponse.Results[0]
-	actualVersion := roleDetails.LatestVersion()
+
+	actualVersion, err := roleDetails.LatestVersion()
+	if err != nil {
+		t.Errorf("Error obtaining latest version: %+v", err)
+		return
+	}
 
 	if expectedVersion != actualVersion {
 		t.Errorf("Expected [%s] != actual [%s]", expectedVersion, actualVersion)

--- a/internal/roleinstaller/internal/step/lookuprole.go
+++ b/internal/roleinstaller/internal/step/lookuprole.go
@@ -28,7 +28,10 @@ func lookupRoleDetails(ctx model.Context, role model.Role) (model.Role, error) {
 
 	roleDetails := roleQueryResponse.Results[0]
 	if role.Version == "" {
-		role.Version = roleDetails.LatestVersion()
+		role.Version, err = roleDetails.LatestVersion()
+		if err != nil {
+			return role, fmt.Errorf("Failed to determine latest version for role [%s].\nCaused by: %s", role.Name, err)
+		}
 	}
 	role.Url = fmt.Sprintf("https://github.com/%s/%s/archive/%s.tar.gz", roleDetails.GitHubUser, roleDetails.GitHubRepo, role.Version)
 


### PR DESCRIPTION
The version comparison lib returns returns errors for versions it deems malformed.